### PR TITLE
fix: returns and theme fontSize

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,8 +11,10 @@ module.exports = {
   //     statements: 80,
   //   },
   // },
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
   moduleNameMapper: {
     '^.+\\.svg$': 'jest-transformer-svg',
+    '^@douro-ui/react(.*)$': '<rootDir>/packages/react/src$1',
   },
   testEnvironment: 'jsdom',
   testRegex: ['.+\\.spec.[jt]s(x?)$', '!dist'],

--- a/packages/components/link/src/link.styles.ts
+++ b/packages/components/link/src/link.styles.ts
@@ -13,7 +13,7 @@ export const SpanHiddenStyled = styled.span`
 `;
 
 export const LinkStyled = styled.a<LinkProps>`
-  font-size: ${({ styled }) => styled.fontSize}rem;
+  font-size: ${({ styled }) => styled.fontSize};
   color: ${({ styled }) => styled.color};
   text-decoration: ${props => (props.underline ? 'underline' : 'none')};
   background: none;

--- a/packages/components/link/src/link.types.ts
+++ b/packages/components/link/src/link.types.ts
@@ -5,7 +5,7 @@ export interface LinkStyledProps {
   colorHover?: string;
   colorFocus?: string;
   colorActive?: string;
-  fontSize?: number;
+  fontSize?: string;
   fontWeight?: number;
 }
 

--- a/packages/react/src/context/GlobalStyles.tsx
+++ b/packages/react/src/context/GlobalStyles.tsx
@@ -1,7 +1,6 @@
-import { Global } from '@emotion/react';
-import { css, cx } from '@emotion/css';
+import { Global, css } from '@emotion/react';
 import { fontFamilyDisplay, fontFamilyText } from '../theme/theme.constants';
-import { FC } from 'react';
+import { ReactElement } from 'react';
 
 const defaultGlobalStyles = css`
   @font-face {
@@ -320,6 +319,6 @@ const defaultGlobalStyles = css`
   }
 `;
 
-export const GlobalStyles: FC = ({ styles }: { styles?: string }) => {
-  return <Global styles={cx([defaultGlobalStyles, styles])} />;
+export const GlobalStyles = (): ReactElement => {
+  return <Global styles={defaultGlobalStyles} />;
 };

--- a/packages/react/src/context/ThemeProvider.tsx
+++ b/packages/react/src/context/ThemeProvider.tsx
@@ -1,9 +1,8 @@
 import { ThemeProvider as ThemeProviderEmotion } from '@emotion/react';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import type { Theme } from '../theme/theme.types';
 import { deepMerge } from '../utils/deepMerge';
 import { defaultTheme } from '../theme';
-import { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 
 export const ThemeProvider = ({
   theme,
@@ -11,7 +10,7 @@ export const ThemeProvider = ({
 }: {
   theme?: Theme;
   children: React.ReactNode;
-}): EmotionJSX.Element => {
+}): ReactElement => {
   const mergedTheme = deepMerge({ ...defaultTheme }, theme);
   return (
     <ThemeProviderEmotion theme={mergedTheme}>{children}</ThemeProviderEmotion>

--- a/packages/react/src/theme/theme.ts
+++ b/packages/react/src/theme/theme.ts
@@ -9,7 +9,7 @@ import {
 import { Theme } from './theme.types';
 
 const spaceUnit = 1;
-const fontSize = 1;
+const fontSize = '1rem';
 
 const theme: Theme = {
   name: 'default_theme',

--- a/packages/react/src/theme/theme.types.ts
+++ b/packages/react/src/theme/theme.types.ts
@@ -36,7 +36,7 @@ export type FontFamilyType<FontFamily extends string> = {
 
 export interface Theme {
   name: string;
-  fontSize: number;
+  fontSize: string;
   fontFamily: FontFamilyType<'display' | 'text'>;
   spaceUnit: Record<string, string>;
   fontWeight: { [K in keyof typeof FontWeight]: FontWeight };

--- a/packages/react/src/tokens/palettes/PaletteStory.tsx
+++ b/packages/react/src/tokens/palettes/PaletteStory.tsx
@@ -9,18 +9,18 @@ const Container = styled.div`
 `;
 
 const Title = styled.h1`
-  font-size: ${theme.fontSize * 1.5}rem;
+  font-size: '${theme.typography.heading.h1.desktop.fontSize}rem';
   margin-bottom: ${theme.spaceUnit['spacing-20']};
 `;
 
 const SectionTitle = styled.h2`
-  font-size: ${theme.fontSize * 1.25}rem;
+  font-size: ${theme.typography.heading.h2.desktop.fontSize}rem;
   margin-top: ${theme.spaceUnit['spacing-20']};
   margin-bottom: ${theme.spaceUnit['spacing-08']};
 `;
 
 const SubSectionTitle = styled.h3`
-  font-size: ${theme.fontSize * 1.125}rem;
+  font-size: ${theme.typography.heading.h3.desktop.fontSize}rem;
   margin-top: ${theme.spaceUnit['spacing-08']};
   margin-bottom: ${theme.spaceUnit['spacing-08']};
 `;


### PR DESCRIPTION
# Description

- Refactor the returns of ThemeProvider and Globals. The project cannot find the Emotion Element but we can use it as a ReactElement
- Receiving new styles as an argument doesn't cause a re-render on the layout to overwrite the new ones. The theme must use `injectGlobal` to do so.
- Changed font size to rem and string
- Fix problems on tests which were not finding the package react

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
