### PR TITLE
fix: tsc bug when run through lint-staged

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,8 @@
+export default {
+  '*.{ts,tsx}': () => [
+    'yarn run typecheck',
+    'yarn run prettier:fix',
+    'yarn run lint:fix',
+  ],
+  '*.{ts,tsx,json,md,scss,yaml,yml}': ['yarn run stylelint:fix'],
+};

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch --no-coverage",
     "test:storybook": "test-storybook",
-    "typecheck": "tsc -b"
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.1",
@@ -92,16 +92,6 @@
   },
   "resolutions": {
     "tar": "^6.2.1"
-  },
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "yarn run typecheck",
-      "yarn run lint:fix",
-      "yarn run stylelint:fix"
-    ],
-    "*.{ts,tsx,json,md,scss,yaml,yml}": [
-      "yarn run prettier:fix"
-    ]
   },
   "engines": {
     "node": ">=20",


### PR DESCRIPTION
# Description
This pr fixes the problem where TSC was not working properly running through lint-staged.
Lint-staged by default passes all staged file locations as a parameter for each command, but tsc was not dealing with it correctly.
The solution is to surpass it by creating a new .mjs file for lint-staged and returning a function instead of an array.

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
