### PR TITLE
fix: modal closing

### DIFF
--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -3,9 +3,10 @@ import {
   ModalBodyStyled,
   ModalContainerStyled,
   ModalContentStyled,
+  ModalContetWrapperStyled,
 } from './modal.styles';
 import { deepMerge, useTheme } from '@douro-ui/react';
-import { ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect, useRef } from 'react';
 import { ModalFooter } from './modalTypes';
 import { ModalHeader } from './modalTypes/ModalHeader';
 
@@ -18,9 +19,11 @@ const Modal = ({
   styled,
   isOpen,
   onClose,
+  closeOnOutsideClick = true,
   ...props
 }: ModalProps): ReactNode => {
   const theme = useTheme();
+  const modalRef = useRef<HTMLDivElement>(null);
 
   const defaultThemeValues: ModalStyledProps = {
     color: theme.colors.neutral.silver.shade20,
@@ -49,40 +52,65 @@ const Modal = ({
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [onClose]);
+  }, [onClose, isOpen]);
+
+  const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      closeOnOutsideClick &&
+      modalRef.current &&
+      !modalRef.current.contains(event.target as Node)
+    ) {
+      onClose();
+    }
+  };
 
   return (
     <>
       {isOpen && (
-        <ModalContainerStyled size={size} {...props}>
-          <ModalContentStyled
-            styled={mergedThemeValues as Required<ModalStyledProps>}
-          >
-            {headerTitle != undefined && (
-              <ModalHeader
-                className="modal-header"
-                size={size}
-                styled={styledHeader}
-                headerTitle={headerTitle}
-                onClose={onClose}
-              />
-            )}
-
-            <ModalBodyStyled
-              className="modal-body"
-              size={size}
+        <ModalContetWrapperStyled
+          data-testid="modal-overlay"
+          size={size}
+          onClick={handleOverlayClick}
+        >
+          <ModalContainerStyled size={size} {...props}>
+            <ModalContentStyled
+              data-testid="modal-content"
+              ref={modalRef}
               styled={mergedThemeValues as Required<ModalStyledProps>}
+              onClick={(e: React.MouseEvent<HTMLDivElement>) =>
+                e.stopPropagation()
+              }
             >
-              {childrenBody}
-            </ModalBodyStyled>
+              {typeof headerTitle !== 'undefined' && (
+                <ModalHeader
+                  className="modal-header"
+                  size={size}
+                  styled={styledHeader}
+                  headerTitle={headerTitle}
+                  onClose={onClose}
+                />
+              )}
 
-            {childrenFooter && (
-              <ModalFooter className="modal-footer" size={size} styled={styled}>
-                {childrenFooter}
-              </ModalFooter>
-            )}
-          </ModalContentStyled>
-        </ModalContainerStyled>
+              <ModalBodyStyled
+                className="modal-body"
+                size={size}
+                styled={mergedThemeValues as Required<ModalStyledProps>}
+              >
+                {childrenBody}
+              </ModalBodyStyled>
+
+              {childrenFooter && (
+                <ModalFooter
+                  className="modal-footer"
+                  size={size}
+                  styled={styled}
+                >
+                  {childrenFooter}
+                </ModalFooter>
+              )}
+            </ModalContentStyled>
+          </ModalContainerStyled>
+        </ModalContetWrapperStyled>
       )}
     </>
   );

--- a/packages/components/modal/src/__tests__/Modal.spec.tsx
+++ b/packages/components/modal/src/__tests__/Modal.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '../../../../../tests/test-utils';
 import Modal from '../Modal';
 import Button from '@douro-ui/button';
 import { ModalProps, ShirtSize } from '../modal.types';
+import { ModalHeader } from '../modalTypes/ModalHeader';
 
 const ModalWithButton = ({ onClose, ...props }: ModalProps) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -55,6 +56,16 @@ describe('<Modal />', () => {
     expect(screen.getByTestId('modal-id')).toHaveStyle('width: 40vw');
   });
 
+  it('does not render footer when childrenFooter is not provided', () => {
+    render(
+      <ModalWithButton onClose={() => {}} headerTitle="No Footer Modal" />,
+    );
+
+    fireEvent.click(screen.getByText('Open modal'));
+
+    expect(document.querySelector('.modal-footer')).not.toBeInTheDocument();
+  });
+
   it('renders footer', () => {
     render(
       <ModalWithButton
@@ -70,6 +81,33 @@ describe('<Modal />', () => {
     fireEvent.click(screen.getByText('Open modal'));
 
     expect(screen.getByText('Confirm')).toBeInTheDocument();
+    expect(document.querySelector('.modal-footer')).toBeInTheDocument();
+  });
+
+  it('does not close modal when clicking inside modal content (stopPropagation)', () => {
+    render(<ModalWithButton onClose={jest.fn()} headerTitle="Test Header" />);
+
+    fireEvent.click(screen.getByText('Open modal'));
+
+    const modalContent = screen.getByTestId('modal-content');
+    fireEvent.click(modalContent);
+
+    expect(screen.getByText('Test Header')).toBeInTheDocument();
+  });
+
+  it('closes the modal when clicking outside the modal (overlay click)', () => {
+    const onCloseMock = jest.fn();
+
+    render(<ModalWithButton onClose={onCloseMock} size={ShirtSize.md} />);
+
+    fireEvent.click(screen.getByText('Open modal'));
+
+    const overlay = screen.getByTestId('modal-overlay');
+    fireEvent.mouseDown(overlay);
+    fireEvent.mouseUp(overlay);
+    fireEvent.click(overlay);
+
+    expect(onCloseMock).toHaveBeenCalled();
   });
 
   it('closes the modal when the Escape key is pressed', () => {
@@ -85,5 +123,24 @@ describe('<Modal />', () => {
     fireEvent.keyDown(window, { key: 'Escape', code: 'Escape', charCode: 27 });
 
     expect(bodyElement).not.toBeInTheDocument();
+  });
+});
+
+describe('<ModalHeader />', () => {
+  it('calls onClose when close button is clicked', () => {
+    const onCloseMock = jest.fn();
+
+    render(
+      <ModalHeader
+        headerTitle="Header Text"
+        onClose={onCloseMock}
+        size={ShirtSize.md}
+      />,
+    );
+
+    const button = screen.getByLabelText('Close modal');
+    fireEvent.click(button);
+
+    expect(onCloseMock).toHaveBeenCalled();
   });
 });

--- a/packages/components/modal/src/modal.styles.ts
+++ b/packages/components/modal/src/modal.styles.ts
@@ -33,6 +33,21 @@ const handleBodyPadding = (size: ModalProps['size']) => {
   }
 };
 
+export const ModalContetWrapperStyled = styled.div<{
+  size: ModalProps['size'];
+}>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: transparent;
+  z-index: 999;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const ModalContainerStyled = styled.div<{
   size: ModalProps['size'];
 }>`
@@ -45,6 +60,7 @@ export const ModalContainerStyled = styled.div<{
   text-align: center;
   background-color: transparent;
   ${({ size }) => handleSize(size)};
+  z-index: 1000;
 `;
 
 export const ModalContentStyled = styled.div<{
@@ -107,4 +123,13 @@ export const ModalFooterStyled = styled.div<{
   gap: 1rem;
   background-color: ${({ styled }) => styled.backgroundColor};
   color: ${({ styled }) => styled.color};
+`;
+
+export const ModalHeaderButtonContainer = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
 `;

--- a/packages/components/modal/src/modal.types.ts
+++ b/packages/components/modal/src/modal.types.ts
@@ -14,6 +14,7 @@ export interface ModalProps extends HTMLAttributes<HTMLDivElement> {
   styledHeader?: ModalStyledProps;
   styled?: ModalStyledProps;
   isOpen?: boolean;
+  closeOnOutsideClick?: boolean;
   onClose: () => void;
 }
 

--- a/packages/components/modal/src/modalTypes/ModalHeader.tsx
+++ b/packages/components/modal/src/modalTypes/ModalHeader.tsx
@@ -1,5 +1,9 @@
 import { ModalHeaderProps, ModalStyledProps } from '../modal.types';
-import { ModalHeaderStyled, ModalIconStyled } from '../modal.styles';
+import {
+  ModalHeaderButtonContainer,
+  ModalHeaderStyled,
+  ModalIconStyled,
+} from '../modal.styles';
 import { deepMerge, useTheme } from '@douro-ui/react';
 import { ReactNode } from 'react';
 
@@ -32,8 +36,15 @@ export const ModalHeader = ({
       styled={mergedThemeValues as Required<ModalStyledProps>}
     >
       {headerTitle}
-
-      <ModalIconStyled data-testid="close-button" onClick={onClose} />
+      <ModalHeaderButtonContainer
+        type="button"
+        aria-label="Close modal"
+        onClick={() => {
+          onClose();
+        }}
+      >
+        <ModalIconStyled />
+      </ModalHeaderButtonContainer>
     </ModalHeaderStyled>
   );
 };


### PR DESCRIPTION
Added a container to be able to click on the svg icon, also added a prop if we want to close the modal when an outside click happens.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
